### PR TITLE
Configure Server Name Indication when creating TLS connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ Gofer new
 
 
 ## Travis Status [![Build Status](https://travis-ci.org/GsDevKit/zinc.png?branch=gs_master)](https://travis-ci.org/GsDevKit/zinc)
+

--- a/README.md
+++ b/README.md
@@ -51,4 +51,3 @@ Gofer new
 
 
 ## Travis Status [![Build Status](https://travis-ci.org/GsDevKit/zinc.png?branch=gs_master)](https://travis-ci.org/GsDevKit/zinc)
-

--- a/repository/Zinc-HTTP.package/ZnNetworkingUtils.class/instance/socketStreamToUrlDirectly..st
+++ b/repository/Zinc-HTTP.package/ZnNetworkingUtils.class/instance/socketStreamToUrlDirectly..st
@@ -5,7 +5,11 @@ socketStreamToUrlDirectly: url
 	stream := (self streamClassForScheme: url scheme) 
 		openConnectionToHost: address
 		port: url portOrDefault
-		timeout: self timeout.  
-	self setSocketStreamParameters: stream.  
-	(#(https wss) includes: url scheme) ifTrue: [ stream connect ].  
+		timeout: self timeout.	
+	self setSocketStreamParameters: stream.	
+	(#(https wss) includes: url scheme)
+		ifTrue:
+			[stream
+				serverNameIndication: url host;
+				connect].	
 	^ stream


### PR DESCRIPTION
ZnHTTPSTests>>#testAmazonAWS failed due to lack of SNI data. This change depends on https://github.com/GsDevKit/zodiac/pull/14 which should be merged first.

In cases where GemStone does not support SNI, this change acts as a NOOP.