### PR TITLE
Referencing itself forces next library to load Zinc from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ to deal with the HTTP networking protocol.
 
 [MIT Licensed](https://github.com/svenvc/zinc/blob/master/license.txt)
 
+
 ## Loading into GemStone
 
 1. Upgrade to the latest version of Metacello and Grease using [GsUpgrader](https://github.com/GsDevKit/gsUpgrader#gsupgrader-):

--- a/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
+++ b/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
@@ -121,11 +121,11 @@ baseline: spec
 							spec
 								loads: #('Base' 'Announcements');
 								repository: 'github://glassdb/glass:master/repository' ];
-				configuration: 'GsPharo'
+				baseline: 'PharoCompatibility'
 					with: [ 
 							spec
-								version: '0.9.3';
-								repository: 'http://seaside.gemtalksystems.com/ss/PharoCompat' ];
+								loads: #('Core');
+								repository: 'github://GsDevKit/PharoCompatibility:master/repository' ];
 				baseline: 'Cryptography'
 					with: [ 
 							spec
@@ -151,7 +151,7 @@ baseline: spec
 							spec
 								requires: #('GLASS1' 'Zinc-FileSystem-Legacy');
 								includes: #('SocketStream') ];
-				package: 'Zinc-Tests' with: [ spec requires: #('GsPharo') ].
+				package: 'Zinc-Tests' with: [ spec requires: #('PharoCompatibility') ].
 			spec
 				group: 'Core' with: #('Zinc-GemStone-Server-Tools');
 				group: 'CI' with: #('REST' 'WebSocket');

--- a/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
+++ b/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
@@ -114,7 +114,6 @@ baseline: spec
 	spec
 		for: #'gemstone'
 		do: [ 
-			spec repository: 'github://GsDevKit/zinc:gs_master/repository'.
 			spec
 				baseline: 'GLASS1'
 					with: [ 


### PR DESCRIPTION
- Even when loading Zinc using `filetree://` referencing its *own github path* causes the next library after Zinc to load from github *not* from filetree. The next library could be e.g. Parasol or Seaside.

- The reference to itself seems to be superfluous.  If the library would be loaded using Metacello, then the repository is defined using `#repository:` which, in case github is used, will reference to it anyways.