### PR TITLE
Updating GsPharo reference to github

### DIFF
--- a/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
+++ b/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
@@ -121,11 +121,11 @@ baseline: spec
 							spec
 								loads: #('Base' 'Announcements');
 								repository: 'github://glassdb/glass:master/repository' ];
-				configuration: 'GsPharo'
+				baseline: 'PharoCompatibility'
 					with: [ 
 							spec
-								version: '0.9.3';
-								repository: 'http://seaside.gemtalksystems.com/ss/PharoCompat' ];
+								loads: #('Core');
+								repository: 'github://GsDevKit/PharoCompatibility:master/repository' ];
 				baseline: 'Cryptography'
 					with: [ 
 							spec
@@ -151,7 +151,7 @@ baseline: spec
 							spec
 								requires: #('GLASS1' 'Zinc-FileSystem-Legacy');
 								includes: #('SocketStream') ];
-				package: 'Zinc-Tests' with: [ spec requires: #('GsPharo') ].
+				package: 'Zinc-Tests' with: [ spec requires: #('PharoCompatibility') ].
 			spec
 				group: 'Core' with: #('Zinc-GemStone-Server-Tools');
 				group: 'CI' with: #('REST' 'WebSocket');


### PR DESCRIPTION
Replacing Monticello  with Metacello.

Updating the repository reference from http://seaside.gemtalksystems.com/ss/PharoCompat to github://GsDevKit/PharoCompatibility:master/repository.