### PR TITLE
Return of WebSocket test and adding comments

### DIFF
--- a/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
+++ b/repository/BaselineOfZincHTTPComponents.package/BaselineOfZincHTTPComponents.class/instance/baseline..st
@@ -75,13 +75,13 @@ baseline: spec
 	spec
 		for: #'squeakCommon'
 		do: [ 
-			spec
+			"spec
 				configuration: 'NeoJSON'
 					with: [ 
 							spec
 								versionString: #'stable';
 								repository: 'http://mc.stfx.eu/Neo' ];
-				yourself.
+				yourself."
 			spec
 				package: 'Zinc-Patch-HTTPSocket' with: [ spec requires: 'Zinc-HTTP' ];
 				package: 'Zinc-Zodiac'

--- a/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEcho.st
+++ b/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEcho.st
@@ -1,5 +1,6 @@
 testing
 testEcho
+  "Needs to be executed in ZnGsWebSocketTests context"
   | webSocket message gemServer |
   gemServer := self createGemServerMap: 'ws-echo' to: ZnWebSocketEchoHandler new.
   self

--- a/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEchoSecureWebSocketsDotOrg.st
+++ b/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEchoSecureWebSocketsDotOrg.st
@@ -6,5 +6,15 @@ testEchoSecureWebSocketsDotOrg
 	webSocket := self webSocketClass to: 'wss://echo.websocket.org'.
 	message := 'Greetings from Gemstone Smalltalk @ ' , TimeStamp now printString.
 	webSocket sendMessage: message.
+
+	"The following server reply line is not specified in the [RFC6455].
+	It is specific to echo.websocket.org server. The server is coded in Go programming language.
+	Implementation details:
+		- The hash (after by) is the return type of the os.Hostname() function (name string, err error),
+		  it returns a string containing the host name reported by the kernel and error if any.
+		- The source code: https://github.com/ably/echo.websocket.org/blob/ffe04c5ff499270b04c5bf2a2db2ee30fccee50a/cmd/echo-server/main.go#L147"
+	self assert: webSocket readMessage equals: 'Request served by 4d896d95b55478'.
+
+	"The actual response of echo"
 	self assert: webSocket readMessage equals: message.
 	webSocket close

--- a/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEchoSecureWebSocketsDotOrg.st
+++ b/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEchoSecureWebSocketsDotOrg.st
@@ -1,10 +1,7 @@
 testing
 testEchoSecureWebSocketsDotOrg
+	"Needs to be executed in ZnGsWebSocketTests context"
 	| webSocket message |
-	true
-		ifTrue: [ 
-			"echo.websocket.org is no longer available. See https://github.com/GsDevKit/zinc/issues/96"
-			^ self ].
 	(Smalltalk at: #'GsSecureSocket') disableCertificateVerificationOnClient.
 	webSocket := self webSocketClass to: 'wss://echo.websocket.org'.
 	message := 'Greetings from Gemstone Smalltalk @ ' , TimeStamp now printString.

--- a/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEchoWebSocketsDotOrg.st
+++ b/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testEchoWebSocketsDotOrg.st
@@ -3,7 +3,7 @@ testEchoWebSocketsDotOrg
 	| webSocket message |
 	true
 		ifTrue: [ 
-			"echo.webserver.org is no longer available ...  is no longer available. See https://github.com/GsDevKit/zinc/issues/96"
+			"ws://echo.webserver.org is sending 301 response (premanently moved).  It has moved to secure alterantive wss://."
 			^ self ].
 	webSocket := self webSocketClass to: 'ws://echo.websocket.org'.
 	message := 'Greetings from Gemstone Smalltalk @ ' , TimeStamp now printString.

--- a/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testStatus.st
+++ b/repository/Zinc-WebSocket-Tests.package/ZnWebSocketTests.class/instance/testStatus.st
@@ -1,5 +1,6 @@
 testing
 testStatus
+  "Needs to be executed in ZnGsWebSocketTests context"
   | webSocket message gemServer |
   gemServer := self
     createGemServerMap: 'ws-status'


### PR DESCRIPTION
In this patch I'm adding  comments to make it clear that these tests need to be run in the correct context.

I'm also activating test:  `testEchoSecureWebSocketsDotOrg` which was deactivated due to `https://github.com/GsDevKit/zinc/issues/96`.  The issue was/is that `webserver.org` have disabled the plain text `ws://` protocol and support only the secure version of it `wss://`.

I have removed the code that skips the tests and added a comment for the `ws://` protocol explaining the situation.